### PR TITLE
added export to the CPPUTEST_HOME env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ its tests.
 ```
 MOUNT_DIR=$PWD:/usr/src
 WORKING_DIR=/usr/src/tddec-code
-CPPUTEST_HOME=$WORKING_DIR/cpputest
+export CPPUTEST_HOME=$WORKING_DIR/cpputest
 docker run -it  -v $MOUNT_DIR -w $WORKING_DIR -e CPPUTEST_HOME gcc:7 make
 ```
 


### PR DESCRIPTION
The -e flag of Docker requires that the environment variable specified be exported prior to command invocation, as stated at https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file